### PR TITLE
【Fixed】アジェンダの削除機能を実装すること（紐づいている記事も削除し、そのアジェンダのチームに属しているメンバー全員に通知メールを送信すること）

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -13,3 +13,16 @@
  *= require_tree .
  *= require_self
  */
+.sidebar .nav-sidebar .agenda_title {
+  display: inline-block;
+  padding: 5px 36px 5px 10px;
+
+}
+.sidebar .nav-sidebar .nav-item .agenda_title .nav-icon {
+  width: 0;
+  margin: 0;
+}
+.sidebar .nav-sidebar .agenda_title,
+.sidebar .nav-sidebar .aagenda_delete {
+  vertical-align: middle;
+}

--- a/app/controllers/agendas_controller.rb
+++ b/app/controllers/agendas_controller.rb
@@ -23,8 +23,12 @@ class AgendasController < ApplicationController
   end
 
   def destroy
-    @agenda.destroy
-    redirect_to dashboard_url, notice: I18n.t('views.messages.delete_agenda')
+    if current_user == @agenda.user || current_user == @agenda.team.owner
+      @agenda.destroy
+      redirect_to dashboard_url, notice: I18n.t('views.messages.delete_agenda')
+    else
+      redirect_to dashboard_url, notice: I18n.t('views.messages.cannot_delete_agenda')
+    end
   end
 
   private

--- a/app/controllers/agendas_controller.rb
+++ b/app/controllers/agendas_controller.rb
@@ -25,6 +25,7 @@ class AgendasController < ApplicationController
   def destroy
     if current_user == @agenda.user || current_user == @agenda.team.owner
       @agenda.destroy
+      DeleteAgendaMailer.delete_agenda_mails(@agenda)
       redirect_to dashboard_url, notice: I18n.t('views.messages.delete_agenda')
     else
       redirect_to dashboard_url, notice: I18n.t('views.messages.cannot_delete_agenda')

--- a/app/controllers/agendas_controller.rb
+++ b/app/controllers/agendas_controller.rb
@@ -1,5 +1,6 @@
 class AgendasController < ApplicationController
   # before_action :set_agenda, only: %i[show edit update destroy]
+  before_action :set_agenda, only: %i[destroy]
 
   def index
     @agendas = Agenda.all
@@ -15,10 +16,15 @@ class AgendasController < ApplicationController
     @agenda.team = Team.friendly.find(params[:team_id])
     current_user.keep_team_id = @agenda.team.id
     if current_user.save && @agenda.save
-      redirect_to dashboard_url, notice: I18n.t('views.messages.create_agenda') 
+      redirect_to dashboard_url, notice: I18n.t('views.messages.create_agenda')
     else
       render :new
     end
+  end
+
+  def destroy
+    @agenda.destroy
+    redirect_to dashboard_url, notice: I18n.t('views.messages.delete_agenda')
   end
 
   private

--- a/app/mailers/delete_agenda_mailer.rb
+++ b/app/mailers/delete_agenda_mailer.rb
@@ -1,0 +1,12 @@
+class DeleteAgendaMailer < ApplicationMailer
+  def delete_agenda_mail(user)
+    @user = user
+    mail to: @user.email, subject: I18n.t('views.messages.delete_agenda_mail_subject')
+  end
+
+  def self.delete_agenda_mails(agenda)
+    agenda.team.users.each do |user|
+      DeleteAgendaMailer.delete_agenda_mail(user).deliver_now
+    end
+  end
+end

--- a/app/views/delete_agenda_mailer/delete_agenda_mail.erb
+++ b/app/views/delete_agenda_mailer/delete_agenda_mail.erb
@@ -1,0 +1,2 @@
+<h1><%= I18n.t('views.messages.delete_agenda_mail_subject') %></h1>
+<p><%= I18n.t('views.messages.delete_agenda_mail_content') %></p>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,6 +10,7 @@ scratch. This page gets rid of all links and provides the needed markup only.
     <meta http-equiv="x-ua-compatible" content="ie=edge">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
+    <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload' %>
 
     <title>diveintopost</title>
 

--- a/app/views/shared/layout/_sidebar.html.erb
+++ b/app/views/shared/layout/_sidebar.html.erb
@@ -30,13 +30,14 @@
       <ul class="nav nav-pills nav-sidebar flex-column" data-widget="treeview" role="menu" data-accordion="false">
         <% @working_team.agendas.each do |agenda| %>
           <li class="nav-item has-treeview menu-open">
-            <a href="#" class="nav-link">
-              <i class="fa fa-circle-o nav-icon"></i>
+            <a href="#" class="nav-link agenda_title">
+              <i class="fa fa-circle-o nav-icon "></i>
               <p>
                 <%= agenda.title %>
                 <i class="right fa fa-angle-left"></i>
               </p>
             </a>
+            <%= link_to I18n.t('views.button.delete'), agenda_path(id: agenda.id), method: :delete, class: 'btn btn-sm btn-danger agenda_delete' %>
             <ul class="nav nav-treeview" style="display: block;">
               <% agenda.articles.each do |article| %>
                 <li class="nav-item">

--- a/app/views/shared/layout/_sidebar.html.erb
+++ b/app/views/shared/layout/_sidebar.html.erb
@@ -37,7 +37,9 @@
                 <i class="right fa fa-angle-left"></i>
               </p>
             </a>
+            <% if current_user == agenda.user || current_user == agenda.team.owner %>
             <%= link_to I18n.t('views.button.delete'), agenda_path(id: agenda.id), method: :delete, class: 'btn btn-sm btn-danger agenda_delete' %>
+            <% end %>
             <ul class="nav nav-treeview" style="display: block;">
               <% agenda.articles.each do |article| %>
                 <li class="nav-item">

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -261,6 +261,8 @@ ja:
       posted_articles: '投稿した記事一覧'
       change_owner_mail_subject: 'リーダー権限変更のお知らせ'
       change_owner_mail_content: 'リーダー権限があなたに渡されました'
+      delete_agenda_mail_subject: 'アジェンダ削除のお知らせ'
+      delete_agenda_mail_content: '貴方の所属するチームのアジェンダが削除されました'
     button:
       submit: '投稿'
       edit: '編集'

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -206,6 +206,7 @@ ja:
   views:
     messages:
       create_agenda: 'アジェンダ作成に成功しました！'
+      create_agenda: 'アジェンダを削除しました'
       create_article: '記事作成に成功しました！'
       update_article: '記事更新に成功しました！'
       assigned: 'アサインしました！'

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -206,7 +206,8 @@ ja:
   views:
     messages:
       create_agenda: 'アジェンダ作成に成功しました！'
-      create_agenda: 'アジェンダを削除しました'
+      delete_agenda: 'アジェンダを削除しました'
+      cannot_delete_agenda: 'アジェンダを削除する権限がありません'
       create_article: '記事作成に成功しました！'
       update_article: '記事更新に成功しました！'
       assigned: 'アサインしました！'

--- a/spec/mailers/delete_agenda_mailer_spec.rb
+++ b/spec/mailers/delete_agenda_mailer_spec.rb
@@ -1,0 +1,5 @@
+require "rails_helper"
+
+RSpec.describe DeleteAgendaMailer, type: :mailer do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/mailers/previews/delete_agenda_mailer_preview.rb
+++ b/spec/mailers/previews/delete_agenda_mailer_preview.rb
@@ -1,0 +1,4 @@
+# Preview all emails at http://localhost:3000/rails/mailers/delete_agenda_mailer
+class DeleteAgendaMailerPreview < ActionMailer::Preview
+
+end


### PR DESCRIPTION
お疲れ様です。
アジェンダの削除機能
（紐づいている記事も削除し、そのアジェンダのチームに属しているメンバー全員に通知メールを送信する）
を実装いたしました。
ご確認よろしくお願いいたします。